### PR TITLE
Fix repository URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/hsbt/delegate.
+Bug reports and pull requests are welcome on GitHub at https://github.com/ruby/delegate.


### PR DESCRIPTION
This pull request updates a link to this repository in README.


---

I also checked other default gems that ware published since Ruby 2.7, and confirmed the all of the other repositories have the correct URL in README.
I picked up the repositories from NEWS-2.7.0.

> * The following default gems were published on rubygems.org
>   * benchmark
>   * cgi
>   * delegate
>   * getoptlong
>   * net-pop
>   * net-smtp
>   * open3
>   * pstore
>   * readline
>   * readline-ext
>   * singleton
>                                                                                                                                                                  
>   https://github.com/ruby/ruby/blob/7f3efee1024ba46189aa4a65d08bb87fdcf1bb24/doc/NEWS-2.7.0#label-Stdlib+compatibility+issues+-28excluding+feature+bug+fixes-29

