### PR TITLE
gemspec: Drop unused executables directives

### DIFF
--- a/delegate.gemspec
+++ b/delegate.gemspec
@@ -24,8 +24,6 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z 2>/dev/null`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 2.7'
 end


### PR DESCRIPTION
This PR removes an unused gemspec directive.