### PR TITLE
Migrate set-output to $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - id: versions
         run: |
           versions=$(curl -s 'https://cache.ruby-lang.org/pub/misc/ci_versions/cruby.json' | jq -c '. - ["2.7"]')
-          echo "::set-output name=value::${versions}"
+          echo "value=${versions}" >> $GITHUB_OUTPUT
   test:
     needs: ruby-versions
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/