### PR TITLE
test: remove needless mu_pp

### DIFF
--- a/test/test_delegate.rb
+++ b/test/test_delegate.rb
@@ -3,14 +3,6 @@ require 'test/unit'
 require 'delegate'
 
 class TestDelegateClass < Test::Unit::TestCase
-  module PP
-    def mu_pp(obj)
-      str = super
-      str = "#<#{obj.class}: #{str}>" if Delegator === obj
-      str
-    end
-  end
-
   module M
     attr_reader :m
   end
@@ -215,7 +207,6 @@ class TestDelegateClass < Test::Unit::TestCase
   end
 
   def test_eql?
-    extend PP
     s0 = SimpleDelegator.new("foo")
     s1 = SimpleDelegator.new("bar")
     s2 = SimpleDelegator.new("foo")


### PR DESCRIPTION
It's for minitest. We don't need it with test-unit.