### PR TITLE
CI: add context on why we don't use bundler-cache: true here [ci skip]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+    # Run bundle separately - "3.0 / macos-latest" was not finding its OpenSSL when using setup-ruby's bundler-cache: true.
     - run: bundle install --jobs 4 --retry 3
     - name: Run test
       run: bundle exec rake test


### PR DESCRIPTION
This PR adds a comment that wants to explain to the reader (like me) what the issue was that made us not use setup-ruby's built-in bundle install.