### PR TITLE
Revert "Run bundle install manually"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - run: bundle install --jobs 4 --retry 3
+        bundler-cache: true # 'bundle install' and cache gems
     - name: Run test
       run: bundle exec rake test


### PR DESCRIPTION
`ruby/setup-ruby` fixed Ruby 3.0 and OpenSSL 3 at macOS platform

----

This reverts commit b2257cc0eeb1b247642777b50dffda38d18beb39.